### PR TITLE
Feat/close with esc

### DIFF
--- a/README.md
+++ b/README.md
@@ -441,7 +441,7 @@ Vimatrix.nvim also exposes the `VimatrixClose` and `VimatrixStop` user-commands,
 that can be called (if the regular means do not work) to stop the ticker and
 close the window or only stop the ticker, respectively.
 
-> !NOTE  
+> [!NOTE]  
 > There is an exception to the normal cancellation procedures when terminal or
 > command-line windows are open and some of the default screensaver settings are
 > altered (see `Known Limitations`)

--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ Install the plugin with your preferred package manager:
     },
   },
   colourscheme = "matrix",
+  cancellation_keys = { "<Esc>", "q" },
   highlight_props = {
     bold = true,
     blend = 1, -- quickfix for loss of highlight contrast with window blend;
@@ -196,6 +197,7 @@ other:
 ---@field window vx.window settings that relate to the window that vimatrix.nvim opens
 ---@field droplet vx.droplet settings that relate to the droplet lanes
 ---@field colourscheme vimatrix.colour_scheme | string
+---@field cancellation_keys string[] temporary keymaps for cancelling the vimatrix effect; assign an empty table to disable vimatrix keymaps
 ---@field highlight_props? vim.api.keyset.highlight Highlight definition to apply to rendered cells, accepts the following keys:
 --- - bg: color name or "#RRGGBB"
 --- - blend: integer between 0 and 100
@@ -428,14 +430,21 @@ which allows for the following effect:
 Vimatrix.nvim generally functions like a screensaver.
 
 You can cancel the effect by `moving the cursor`, `inserting text`, or
-`changing modes`.
+`changing modes`. By default, the `<Esc>` and `q` keys are also configured for
+cancellation.
 
-There is an exception when terminal or command-line windows are open and some of
-the default screensaver settings are altered (see `Known Limitations`)
+These keymaps temporarily override existing keymaps while vimatrix is running
+and restore the original keymaps (if present) when vimatrix closes. The keys
+themselves are configurable.
 
 Vimatrix.nvim also exposes the `VimatrixClose` and `VimatrixStop` user-commands,
 that can be called (if the regular means do not work) to stop the ticker and
 close the window or only stop the ticker, respectively.
+
+> !NOTE  
+> There is an exception to the normal cancellation procedures when terminal or
+> command-line windows are open and some of the default screensaver settings are
+> altered (see `Known Limitations`)
 
 ### 🖱 Manual Invocation
 

--- a/README.md
+++ b/README.md
@@ -120,6 +120,9 @@ Install the plugin with your preferred package manager:
     print_errors = false,
     log_level = vim.log.levels.DEBUG,
   },
+  keys = {
+    cancellation = { "<Esc>", "q" },
+  },
 }
 ```
 
@@ -192,12 +195,14 @@ other:
 ---@field timings vx.lane_timings the timings of changes on screen
 ---@field random vx.random the chances of random events; each is a chance of 1 in x
 
+---@class vx.keys
+---@field cancellation string[] temporary keymaps for cancelling the vimatrix effect; assign an empty table to disable vimatrix keymaps
+
 ---@class vx.config
 ---@field auto_activation vx.auto_activation --settings that relate to automatic activation of vimatrix.nvim
 ---@field window vx.window settings that relate to the window that vimatrix.nvim opens
 ---@field droplet vx.droplet settings that relate to the droplet lanes
 ---@field colourscheme vimatrix.colour_scheme | string
----@field cancellation_keys string[] temporary keymaps for cancelling the vimatrix effect; assign an empty table to disable vimatrix keymaps
 ---@field highlight_props? vim.api.keyset.highlight Highlight definition to apply to rendered cells, accepts the following keys:
 --- - bg: color name or "#RRGGBB"
 --- - blend: integer between 0 and 100
@@ -213,6 +218,7 @@ other:
 --- - reverse: boolean
 ---@field alphabet vx.alphabet_props
 ---@field logging vx.log.props error logging settings; BEWARE: errors can ammass quickly if something goes wrong
+---@field keys vx.keys
 ```
 
 </details>

--- a/README.md
+++ b/README.md
@@ -104,7 +104,6 @@ Install the plugin with your preferred package manager:
     },
   },
   colourscheme = "matrix",
-  cancellation_keys = { "<Esc>", "q" },
   highlight_props = {
     bold = true,
     blend = 1, -- quickfix for loss of highlight contrast with window blend;

--- a/README.md
+++ b/README.md
@@ -438,8 +438,8 @@ You can cancel the effect by `moving the cursor`, `inserting text`, or
 `changing modes`. By default, the `<Esc>` and `q` keys are also configured for
 cancellation.
 
-These keymaps temporarily override existing keymaps while vimatrix is running
-and restore the original keymaps (if present) when vimatrix closes. The keys
+These keymaps temporarily override existing ones while vimatrix is running and
+restore the original keymaps (if present) when vimatrix closes. The keys
 themselves are configurable.
 
 Vimatrix.nvim also exposes the `VimatrixClose` and `VimatrixStop` user-commands,

--- a/lua/vimatrix/config.lua
+++ b/lua/vimatrix/config.lua
@@ -42,12 +42,14 @@ local M = {}
 ---@field timings vx.lane_timings the timings of changes on screen
 ---@field random vx.random the chances of random events; each is a chance of 1 in x
 
+---@class vx.keys
+---@field cancellation string[] temporary keymaps for cancelling the vimatrix effect; assign an empty table to disable vimatrix keymaps
+
 ---@class vx.config
 ---@field auto_activation vx.auto_activation --settings that relate to automatic activation of vimatrix.nvim
 ---@field window vx.window settings that relate to the window that vimatrix.nvim opens
 ---@field droplet vx.droplet settings that relate to the droplet lanes
 ---@field colourscheme vimatrix.colour_scheme | string
----@field cancellation_keys string[] temporary keymaps for cancelling the vimatrix effect; assign an empty table to disable vimatrix keymaps
 ---@field highlight_props? vim.api.keyset.highlight Highlight definition to apply to rendered cells, accepts the following keys:
 --- - bg: color name or "#RRGGBB"
 --- - blend: integer between 0 and 100
@@ -63,6 +65,7 @@ local M = {}
 --- - reverse: boolean
 ---@field alphabet vx.alphabet_props
 ---@field logging vx.log.props error logging settings; BEWARE: errors can ammass quickly if something goes wrong
+---@field keys vx.keys
 local defaults = {
 	auto_activation = {
 		screensaver = {
@@ -109,7 +112,6 @@ local defaults = {
 		},
 	},
 	colourscheme = "matrix",
-	cancellation_keys = { "<Esc>", "q" },
 	highlight_props = {
 		bold = true,
 		blend = 1, -- quickfix for loss of highlight contrast with window blend;
@@ -124,6 +126,9 @@ local defaults = {
 	logging = {
 		print_errors = false,
 		log_level = vim.log.levels.DEBUG,
+	},
+	keys = {
+		cancellation = { "<Esc>", "q" },
 	},
 }
 

--- a/lua/vimatrix/config.lua
+++ b/lua/vimatrix/config.lua
@@ -47,6 +47,7 @@ local M = {}
 ---@field window vx.window settings that relate to the window that vimatrix.nvim opens
 ---@field droplet vx.droplet settings that relate to the droplet lanes
 ---@field colourscheme vimatrix.colour_scheme | string
+---@field cancellation_keys string[] temporary keymaps for cancelling the vimatrix effect; assign an empty table to disable vimatrix keymaps
 ---@field highlight_props? vim.api.keyset.highlight Highlight definition to apply to rendered cells, accepts the following keys:
 --- - bg: color name or "#RRGGBB"
 --- - blend: integer between 0 and 100
@@ -108,6 +109,7 @@ local defaults = {
 		},
 	},
 	colourscheme = "matrix",
+	cancellation_keys = { "<Esc>", "q" },
 	highlight_props = {
 		bold = true,
 		blend = 1, -- quickfix for loss of highlight contrast with window blend;

--- a/lua/vimatrix/init.lua
+++ b/lua/vimatrix/init.lua
@@ -10,7 +10,7 @@ local rain = function(props)
 	local events = { "CursorMoved", "CursorMovedI", "ModeChanged", "InsertCharPre" }
 	local _ = props and props.focus_listener and table.insert(events, "FocusLost") or nil
 
-	require("vimatrix.orchestrator").rain(events, config.options.cancellation_keys)
+	require("vimatrix.orchestrator").rain(events, config.options.keys.cancellation)
 end
 
 local function auto_activate_after_timeout()

--- a/lua/vimatrix/init.lua
+++ b/lua/vimatrix/init.lua
@@ -10,7 +10,7 @@ local rain = function(props)
 	local events = { "CursorMoved", "CursorMovedI", "ModeChanged", "InsertCharPre" }
 	local _ = props and props.focus_listener and table.insert(events, "FocusLost") or nil
 
-	require("vimatrix.orchestrator").rain(events)
+	require("vimatrix.orchestrator").rain(events, config.options.cancellation_keys)
 end
 
 local function auto_activate_after_timeout()

--- a/lua/vimatrix/screensaver.lua
+++ b/lua/vimatrix/screensaver.lua
@@ -59,6 +59,15 @@ function M.setup(props)
 			})
 		end
 
+		vim.api.nvim_create_autocmd("User", {
+			pattern = "VimatrixUndo",
+			callback = function()
+				if not require("vimatrix.timer").has_stopped() then -- prevents unintended resets if event arrives while screensaver timer is not ticking
+					reset()
+				end
+			end,
+		})
+
 		vim.api.nvim_create_autocmd({ "CursorMoved", "CursorMovedI", "ModeChanged", "InsertCharPre" }, {
 			callback = reset,
 		})

--- a/lua/vimatrix/utils.lua
+++ b/lua/vimatrix/utils.lua
@@ -1,0 +1,74 @@
+local M = {}
+
+local function keymaps_find(keymaps, key)
+	for _, existing in ipairs(keymaps) do
+		if existing.lhs == key then
+			return existing
+		end
+	end
+	return nil
+end
+
+---@class keymaps
+---@field key string
+---@field existing vim.api.keyset.get_keymap
+
+---@param bufid integer buffer_id
+---@param keys string[] keys for which to list keymaps
+---@return keymaps[]
+function M.keymaps_list_buf(bufid, keys)
+	local keymaps = vim.api.nvim_buf_get_keymap(bufid, "n")
+	local maps = {}
+	for _, ck in ipairs(keys) do
+		local match = keymaps_find(keymaps, ck)
+		if match then
+			table.insert(maps, { key = ck, existing = match })
+		else
+			table.insert(maps, { key = ck })
+		end
+	end
+	return maps
+end
+
+--- currently assumes remap
+---@param bufid integer buffer_id
+---@param keys string[] keys to assign
+---@param rhs function|string function or command to execute on keypress
+function M.keymaps_set_all_buf(bufid, keys, rhs)
+	for _, key in ipairs(keys) do
+		vim.keymap.set("n", key, rhs, {
+			buffer = bufid,
+			remap = true,
+		})
+	end
+end
+
+---@param i integer
+---@return boolean
+local function int_to_bool(i)
+	return i and i == 1 or false
+end
+
+---@param bufid integer buffer_id
+---@param keymaps keymaps[]
+function M.keymaps_restore_buf(bufid, keymaps)
+	for _, map in ipairs(keymaps) do
+		if map.existing ~= nil then
+			vim.keymap.set("n", map.key, map.existing.rhs or "", {
+				buffer = bufid,
+				callback = map.existing.callback,
+				desc = map.existing.desc,
+				noremap = int_to_bool(map.existing.noremap),
+				nowait = int_to_bool(map.existing.nowait),
+				script = int_to_bool(map.existing.script),
+				expr = int_to_bool(map.existing.expr),
+				silent = int_to_bool(map.existing.silent),
+			})
+		else
+			-- apply pcall for idempotent behaviour without errors
+			pcall(vim.keymap.del, "n", map.key, { buffer = bufid })
+		end
+	end
+end
+
+return M


### PR DESCRIPTION
# Features

- adds configurable keymaps for cancelling the vimatrix effect
- configured keymaps override colliding (buffer-local) keymaps for the duration of the vimatrix effect
- (buffer-local) keymaps are restored upon cancellation of the effect (regardless of the means of cancellation)